### PR TITLE
Fix typo in Context7 MCP rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document defines the project's rules, objectives, and progress management m
 
 - To maximize efficiency, **if you need to execute multiple independent processes, invoke those tools concurrently, not sequentially**.
 - **You must think exclusively in English**. However, you are required to **respond in Japanese**.
-- To understand how to use a library, **always use the Contex7 MCP** to retrieve the latest information.
+- To understand how to use a library, **always use the Context7 MCP** to retrieve the latest information.
 - For temporary notes for design, create a markdown in `.tmp` and save it.
 - **After using Write or Edit tools, ALWAYS verify the actual file contents using the Read tool**, regardless of what the system-reminder says. The system-reminder may incorrectly show "(no content)" even when the file has been successfully written.
 - Please respond critically and without pandering to my opinions, but please don't be forceful in your criticism.


### PR DESCRIPTION
Corrected a typo in the rule regarding library usage.